### PR TITLE
refactor: Store geometry in SQLite and switch Client List to use data…

### DIFF
--- a/pages/CRM_Client_List.py
+++ b/pages/CRM_Client_List.py
@@ -9,7 +9,7 @@ import pandas as pd
 import json
 from typing import Optional, Dict
 
-from src.crm_client_storage import CRMClientStorage
+from src.crm_mapping_storage import CRMMappingStorage
 from src.list_storage import ListStorage
 from src.components import render_crm_client_selector, create_map
 from streamlit_folium import st_folium
@@ -297,7 +297,7 @@ def main():
     # Sidebar configuration and saved lists
     with st.sidebar:
         st.header("⚙️ Configuration")
-        st.info("CRM clients are loaded from `crm_data/clients.json`")
+        st.info("CRM clients are loaded from SQLite database (CRM Mappings)")
 
         st.write("---")
 
@@ -309,14 +309,14 @@ def main():
 
     st.write("---")
 
-    # Load CRM client data
-    crm_storage = CRMClientStorage()
-    clients_data = crm_storage.load_clients()
+    # Load CRM mappings (clients) from database
+    crm_storage = CRMMappingStorage(db_path="./data/crm_mappings.db")
+    clients_data = crm_storage.get_all_mappings()
 
     if not clients_data:
         st.error(
-            "No CRM client data found. Please ensure `crm_data/clients.json` exists. "
-            "You can create this file by exporting mappings from the CRM Mapping page."
+            "No CRM mappings found in database. "
+            "Please create CRM mappings first in the CRM Mapping page."
         )
         st.stop()
 

--- a/pages/CRM_Mapping.py
+++ b/pages/CRM_Mapping.py
@@ -106,6 +106,9 @@ def render_mapping_form(storage: CRMMappingStorage):
         else:
             # Try to add the mapping (DB will enforce 1:1 constraints)
             try:
+                # Get geometry from selected boundary if available
+                geometry = selected.get('geometry')
+
                 storage.add_mapping(
                     system_id=custom_id.strip(),
                     account_name=account_name.strip(),
@@ -113,7 +116,8 @@ def render_mapping_form(storage: CRMMappingStorage):
                     division_id=selected['division_id'],
                     division_name=selected['name'],
                     overture_subtype=selected['subtype'],
-                    country=selected['country']
+                    country=selected['country'],
+                    geometry=geometry
                 )
                 st.success(f"✅ Added mapping for {selected['name']}")
                 st.rerun()


### PR DESCRIPTION
…base

Major refactoring to consolidate data storage and eliminate duplication:

**CRM Mapping Storage (src/crm_mapping_storage.py)**
- Add geometry column to SQLite schema (TEXT type, stores GeoJSON)
- Add migration logic for existing databases (ALTER TABLE if needed)
- Update add_mapping() to accept optional geometry parameter
- Update all query methods to parse geometry from JSON string to dict
- Include geometry in JSON exports

**CRM Mapping Page (pages/CRM_Mapping.py)**
- Extract geometry from selected_boundary session state
- Pass geometry to storage.add_mapping() when creating mappings
- Reuse already-fetched geometry (no expensive Overture re-query)

**CRM Client List Page (pages/CRM_Client_List.py)**
- Replace CRMClientStorage with CRMMappingStorage
- Load clients directly from SQLite database
- Remove dependency on crm_data/clients.json file
- Update sidebar text and error messages
- Geometry now comes from database (no Overture query needed)

Benefits:
- Single source of truth (SQLite database)
- No data duplication or manual JSON maintenance
- Faster map rendering (geometry pre-stored)
- Automatic sync between pages
- Cleaner architecture

This deprecates crm_client_storage.py and crm_data/clients.json (files retained but no longer used by the application).