### PR TITLE
chore: Clean up codebase - remove unused imports and enhance .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,15 @@ __pycache__/
 env/
 venv/
 ENV/
+build/
+dist/
+*.egg-info/
+.eggs/
+.pytest_cache/
+.mypy_cache/
+.tox/
+.coverage
+htmlcov/
 
 # Streamlit
 .streamlit/

--- a/pages/Auto_List_Builder.py
+++ b/pages/Auto_List_Builder.py
@@ -8,7 +8,6 @@ import streamlit as st
 import pandas as pd
 import json
 import os
-from typing import List, Dict
 
 from src.query_engine import create_query_engine
 from src.list_storage import ListStorage

--- a/pages/CRM_Client_List.py
+++ b/pages/CRM_Client_List.py
@@ -7,7 +7,6 @@ Create and export lists of CRM clients based on pre-mapped divisions.
 import streamlit as st
 import pandas as pd
 import json
-from typing import Optional, Dict
 
 from src.list_storage import ListStorage
 from src.crm_mapping_storage import CRMMappingStorage

--- a/pages/CRM_Mapping.py
+++ b/pages/CRM_Mapping.py
@@ -6,14 +6,10 @@ Map Overture administrative divisions to CRM accounts with custom metadata.
 
 import streamlit as st
 import pandas as pd
-import folium
-from streamlit_folium import st_folium
-from typing import Optional, Dict
 import os
 import json
 
 from src.query_engine import create_query_engine
-from src.list_storage import ListStorage
 from src.crm_mapping_storage import CRMMappingStorage
 from src.components import render_boundary_selector, render_map_section
 import sqlite3

--- a/pages/List_Builder.py
+++ b/pages/List_Builder.py
@@ -7,9 +7,6 @@ boundaries from Overture Maps Foundation data.
 
 import streamlit as st
 import pandas as pd
-import folium
-from streamlit_folium import st_folium
-from typing import Optional, Dict
 import os
 
 from src.query_engine import create_query_engine

--- a/pages/List_Visualizer.py
+++ b/pages/List_Visualizer.py
@@ -9,9 +9,8 @@ import streamlit as st
 import pandas as pd
 import folium
 from streamlit_folium import st_folium
-import json
 import os
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 from src.list_storage import ListStorage
 from src.query_engine import create_query_engine
@@ -224,7 +223,7 @@ def render_list_selector_sidebar():
     if boundary_lists:
         list_options.append("--- Boundary Lists ---")
         for lst in boundary_lists:
-            key = f"{lst['source_dir']}|{lst['list_id']}"
+            f"{lst['source_dir']}|{lst['list_id']}"
             label = f"{lst['list_name']} ({lst['boundary_count']} items)"
             list_options.append(label)
             list_map[label] = lst
@@ -232,7 +231,7 @@ def render_list_selector_sidebar():
     if crm_lists:
         list_options.append("--- CRM Client Lists ---")
         for lst in crm_lists:
-            key = f"{lst['source_dir']}|{lst['list_id']}"
+            f"{lst['source_dir']}|{lst['list_id']}"
             label = f"{lst['list_name']} ({lst['boundary_count']} items)"
             list_options.append(label)
             list_map[label] = lst

--- a/src/crm_client_storage.py
+++ b/src/crm_client_storage.py
@@ -7,7 +7,7 @@ Manages loading and filtering of CRM client data from JSON files.
 import json
 import os
 import streamlit as st
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 
 class CRMClientStorage:

--- a/src/crm_mapping_storage.py
+++ b/src/crm_mapping_storage.py
@@ -8,7 +8,6 @@ import sqlite3
 import os
 import json
 from typing import List, Dict, Optional
-from datetime import datetime
 
 
 class CRMMappingStorage:

--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -5,8 +5,6 @@ Generates sample Parquet files mimicking Overture Maps structure for local testi
 """
 
 import duckdb
-import json
-from datetime import datetime
 
 
 def generate_test_parquet(output_path: str = "./tests/test_boundaries.parquet"):


### PR DESCRIPTION
- Remove unused imports from 8 Python files across pages/, src/, and tests/
- Remove unused variables in List_Visualizer.py
- Enhance .gitignore with comprehensive Python patterns (build/, dist/, *.egg-info/, pytest/mypy caches, coverage reports)
- Verify all Python files compile successfully after cleanup